### PR TITLE
Add `HTTP` and `HTTPS` macros to bootdoc.ddoc

### DIFF
--- a/bootdoc.ddoc
+++ b/bootdoc.ddoc
@@ -192,8 +192,10 @@ RPAREN = )
 LPAREN = (
 LESS = &lt;
 GREATER = &gt;
-WEB = $(LINK2 http://$1,$2)
-LUCKY = $(WEB
+HTTP = $(LINK2 http://$1,$2)
+HTTPS = $(LINK2 https://$1,$2)
+WEB = $(HTTP $1,$2)
+LUCKY = $(HTTP
 google.com/search?btnI=I%27m+Feeling+Lucky&amp;ie=UTF-8&amp;oe=UTF-8&amp;q=$0,$0)
 D = <span class="inlinecode">$0</span>
 BIGOH = <b><i>&Omicron;</i>(</b>$(D $0)<b><i>)</i></b>


### PR DESCRIPTION
`WEB` macro is unsafe because `$(WEB http://..., ...)` is a common mistake.
It was removed from dlang.org by [d-programming-language.org/pull #28](https://github.com/D-Programming-Language/d-programming-language.org/pull/28).

`HTTP` macro is better. `HTTPS` added for consistency.
