### PR TITLE
Fix `.symbol` padding

### DIFF
--- a/bootdoc.css
+++ b/bootdoc.css
@@ -1,5 +1,6 @@
 ﻿.symbol {
 	padding-top: 40px;
+	margin-top: -40px;
 }
 
 .sidebar-list-entry {

--- a/bootdoc.ddoc
+++ b/bootdoc.ddoc
@@ -146,7 +146,7 @@ DDOC = <!DOCTYPE html>
 
 DDOC_DECL    = <hr><div class="row-fluid declaration"><h3>$0</h3></div>
 DDOC_DECL_DD = <div class="declaration-content">$0</div>
-DDOC_PSYMBOL = <a class="symbol symbol-anchor" name="$0" href="#$0">$0</a>
+DDOC_PSYMBOL = <span class="symbol" id="$0"></span><a class="symbol-anchor" href="#$0">$0</a>
 DDOC_SYMBOL = <s>$0</s>
 DDOC_SUMMARY = <p>$0</p>
 

--- a/bootdoc.js
+++ b/bootdoc.js
@@ -157,7 +157,7 @@ function buildSymbolTree() {
 			var $decl = $(this);
 			var text = $decl.text();
 			
-			var $symbol = $decl.find('.symbol');
+			var $symbol = $decl.find('.symbol-anchor');
 			var symbol;
 			if($symbol.length == 0) { // Special member (e.g. constructor).
 				symbol = text.match(specialMemberRegex)[0];


### PR DESCRIPTION
Non-zero `.symbol` padding leads to incorrect selection on mouse hover for multiple `DDOC_PSYMBOL`s in one `DDOC_DECL` (a result of `/// ditto`).

For example see http://jakobovrum.github.com/bootdoc-phobos/std.array.html#insertInPlace
