### PR TITLE
Update for D-Programming-Language/dmd#1174

### DIFF
--- a/bootdoc.ddoc
+++ b/bootdoc.ddoc
@@ -146,6 +146,7 @@ DDOC = <!DOCTYPE html>
 
 DDOC_DECL    = <hr><div class="row-fluid declaration"><h3>$0</h3></div>
 DDOC_DECL_DD = <div class="declaration-content">$0</div>
+DDOC_ANCHOR  =
 DDOC_PSYMBOL = <span class="symbol-target" id="$0">&nbsp;</span><a class="symbol-link" href="#$0">$0</a>
 DDOC_SYMBOL = <s>$0</s>
 DDOC_SUMMARY = <p>$0</p>


### PR DESCRIPTION
D-Programming-Language/dmd#1174 pull adds `DDOC_ANCHOR` macro for qualified anchor links which we don't need because it's buggy (e.g. it doesn't support templates members).

So we have to disable it for now and wait until it is fixed.
